### PR TITLE
Update email_qa_enhanced.py for copyright detection

### DIFF
--- a/email_qa_enhanced.py
+++ b/email_qa_enhanced.py
@@ -11,6 +11,7 @@ import logging
 import requests
 import threading
 import queue
+from datetime import datetime
 from bs4 import BeautifulSoup
 from urllib.parse import urlparse, parse_qs
 from runtime_config import config
@@ -344,6 +345,44 @@ def extract_email_metadata(soup):
         logger.info(f"Removing 'r' prefix from campaign code: {footer_campaign_code}")
         footer_campaign_code = footer_campaign_code[1:]
         logger.info(f"Cleaned campaign code: {footer_campaign_code}")
+    
+    # Extract copyright year from footer
+    copyright_year = "Not found"
+    current_year = str(datetime.now().year)
+    
+    # Look for copyright symbol followed by year in various formats
+    copyright_patterns = [
+        r'©\s*(\d{4})',  # © 2025
+        r'@(\d{4})',  # @2025 (common email typo for copyright)
+        r'&copy;\s*(\d{4})',  # &copy; 2025
+        r'copyright\s*©?\s*(\d{4})',  # copyright © 2025 or copyright 2025
+        r'copyright\s*&copy;\s*(\d{4})',  # copyright &copy; 2025
+        r'\(c\)\s*(\d{4})',  # (c) 2025
+        r'©.*?(\d{4})',  # © Company Name 2025 (more flexible)
+        r'copyright.*?(\d{4})',  # copyright text 2025 (more flexible)
+    ]
+    
+    # Search through all text content for copyright year
+    html_content = str(soup)
+    text_content = soup.get_text()
+    
+    for pattern in copyright_patterns:
+        # Check in HTML content first (handles HTML entities)
+        match = re.search(pattern, html_content, re.IGNORECASE)
+        if match:
+            copyright_year = match.group(1)
+            logger.info(f"Found copyright year in HTML: {copyright_year} using pattern: {pattern}")
+            break
+        
+        # Also check in plain text content
+        match = re.search(pattern, text_content, re.IGNORECASE)
+        if match:
+            copyright_year = match.group(1)
+            logger.info(f"Found copyright year in text: {copyright_year} using pattern: {pattern}")
+            break
+    
+    if copyright_year == "Not found":
+        logger.info("No copyright year found in email content")
         
     # Create metadata dictionary with clean field names
     metadata_dict = {
@@ -354,6 +393,9 @@ def extract_email_metadata(soup):
         'preheader': preheader_text,
         'footer_campaign_code': footer_campaign_code
     }
+    
+    # Add copyright year as a regular metadata field with expected value
+    metadata_dict['copyright_year'] = copyright_year
     
     return metadata_dict
 
@@ -1382,6 +1424,10 @@ def validate_email(email_path, requirements_path, check_product_tables=False, pr
                 expected_metadata['campaign_code'] = f"{campaign_code} - {country}"
                 # Also set footer_campaign_code to match the same format
                 expected_metadata['footer_campaign_code'] = f"{campaign_code} - {country}"
+        
+        # Add copyright year as expected metadata for validation
+        current_year = str(datetime.now().year)
+        expected_metadata['copyright_year'] = current_year
         
         # Compare actual vs expected values
         for key, expected_value in expected_metadata.items():


### PR DESCRIPTION
This was a request from a marketing associate to be included in the metadata results section. It's a way to check for errors if/when a copyright date is hardcoded in the ESP token vs dynamically populated.